### PR TITLE
FIXED: problem with disposing container

### DIFF
--- a/TopShelf.Owin/OwinServiceConfiguratorExtensions.cs
+++ b/TopShelf.Owin/OwinServiceConfiguratorExtensions.cs
@@ -13,7 +13,7 @@ namespace TopShelf.Owin
                 appConfigurator(config);
 
             configurator.BeforeStartingService(t => config.Start());
-            configurator.BeforeStoppingService(t => config.Stop());
+            configurator.AfterStoppingService(t => config.Stop());
 
             return configurator;
         }


### PR DESCRIPTION
Container passed down to WebApplication was disposed on BeforeStoppingService() method. 
In case of using the objects resolved from the container on hosted service stop method, it was throwing exception because of they were already disposed.