### PR TITLE
Add explicit 'CreateUsing' call to example

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ namespace YourService
          
                 c.Service<YourService>(s =>
                 {
+                    s.CreateUsing(() => new YourService()); // or a factory, IOC container, etc...
                     s.WhenStarted((service, control) => service.Start());
                     s.WhenStopped((service, control) => service.Stop());
 


### PR DESCRIPTION
I created a console application targeting .NET 4.6.1 (not that it's necessarily relevant).

After adding nuget package TopShelf.Owin and stubbing out a basic YourService class, the following exception is encountered when running:

Configuration Result:
[Success] Name YourService
[Success] ServiceName YourService
Topshelf v3.1.135.0, .NET Framework v4.0.30319.42000
Topshelf.HostFactory Error: 0 : An exception occurred creating the host, Topshel
f.HostConfigurationException: The service was not properly configured:
[Failure] Factory must not be null
   at Topshelf.Configurators.ValidateConfigurationResult.CompileResults(IEnumera
ble`1 results)
   at Topshelf.ServiceExtensions.<>c__DisplayClasse`1.<CreateServiceBuilderFacto
ry>b__d(HostSettings x)
   at Topshelf.HostConfigurators.HostConfiguratorImpl.CreateHost()
   at Topshelf.HostFactory.New(Action`1 configureCallback)
Topshelf.HostFactory Error: 0 : The service terminated abnormally, Topshelf.Host
ConfigurationException: The service was not properly configured:
[Failure] Factory must not be null
   at Topshelf.Configurators.ValidateConfigurationResult.CompileResults(IEnumera
ble`1 results)
   at Topshelf.ServiceExtensions.<>c__DisplayClasse`1.<CreateServiceBuilderFacto
ry>b__d(HostSettings x)
   at Topshelf.HostConfigurators.HostConfiguratorImpl.CreateHost()
   at Topshelf.HostFactory.New(Action`1 configureCallback)
   at Topshelf.HostFactory.Run(Action`1 configureCallback)
Exiting with code [1] (AbnormalExit).
Press ENTER to exit...

After adding an explicit 'CreateUsing' call, this exception clears. (And another unrelated exception takes its place at the moment, but that relates to a separate issue pertaining to a missing Microsoft.Owin.Host.HttpListener reference, which I'll report separately)